### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/java/src/com/marginallyclever/gcodesender/GcodeSender.java
+++ b/java/src/com/marginallyclever/gcodesender/GcodeSender.java
@@ -51,15 +51,15 @@ public class GcodeSender
 extends JPanel
 implements ActionListener, KeyListener, SerialConnectionReadyListener
 {
-	static final long serialVersionUID=1;
-	
-	static String VERSION="1.1.0";
+	private static final long serialVersionUID=1;
+
+	private static String VERSION="1.1.0";
 	static protected GcodeSender singleton=null;
 	
 	// command line
-	JPanel textInputArea;
-	JTextField commandLineText;
-	JButton commandLineSend;
+	private JPanel textInputArea;
+	private JTextField commandLineText;
+	private JButton commandLineSend;
 	
 	// menus
 	static private JFrame mainframe;
@@ -92,8 +92,8 @@ implements ActionListener, KeyListener, SerialConnectionReadyListener
 	private ArrayList<String> gcode;
 	
 	// Generators
-	GcodeGenerator [] generators;
-	JMenuItem generatorButtons[];
+	private GcodeGenerator [] generators;
+	private JMenuItem generatorButtons[];
 
 	
 	public JFrame GetMainFrame() {

--- a/java/src/com/marginallyclever/gcodesender/Generators/HilbertCurveGenerator.java
+++ b/java/src/com/marginallyclever/gcodesender/Generators/HilbertCurveGenerator.java
@@ -18,17 +18,17 @@ import com.marginallyclever.gcodesender.GcodeSender;
 
 // source http://introcs.cs.princeton.edu/java/32class/Hilbert.java.html
 public class HilbertCurveGenerator implements GcodeGenerator {
-	float turtle_x,turtle_y;
-	float turtle_dx,turtle_dy;
-	float turtle_step=10.0f;
-	float xmax = 7;
-	float xmin = -7;
-	float ymax = 7;
-	float ymin = -7;
-	float tool_offset_z = 1.25f;
-	float z_down=40;
-	float z_up=90;
-	int order=4; // controls complexity of curve
+	private float turtle_x,turtle_y;
+	private float turtle_dx,turtle_dy;
+	private float turtle_step=10.0f;
+	private float xmax = 7;
+	private float xmin = -7;
+	private float ymax = 7;
+	private float ymin = -7;
+	private float tool_offset_z = 1.25f;
+	private float z_down=40;
+	private float z_up=90;
+	private int order=4; // controls complexity of curve
 
 	
 	public String GetMenuName() {

--- a/java/src/com/marginallyclever/gcodesender/Generators/YourMessageHereGenerator.java
+++ b/java/src/com/marginallyclever/gcodesender/Generators/YourMessageHereGenerator.java
@@ -37,7 +37,7 @@ public class YourMessageHereGenerator implements GcodeGenerator {
 	protected float letter_height=2.0f;
 	protected float line_spacing=0.50f;
 	protected float padding=0.20f;
-	static final String alphabetFolder = System.getProperty("user.dir") + "/" + "ALPHABET/";
+	private static final String alphabetFolder = System.getProperty("user.dir") + "/" + "ALPHABET/";
 	protected String outputFile = System.getProperty("user.dir") + "/" + "TEMP.NGC";
 	protected int chars_per_line=35;
 	protected String lastMessage = "";

--- a/java/src/com/marginallyclever/gcodesender/SerialConnection.java
+++ b/java/src/com/marginallyclever/gcodesender/SerialConnection.java
@@ -21,12 +21,12 @@ import com.marginallyclever.gcodesender.SerialConnectionReadyListener;
 
 public class SerialConnection
 implements SerialPortEventListener, ActionListener {
-	static final String CUE = "> ";
-	static final String NOCHECKSUM = "NOCHECKSUM ";
-	static final String BADCHECKSUM = "BADCHECKSUM ";
-	static final String BADLINENUM = "BADLINENUM ";
-	static final String NEWLINE = "\n";
-	static final String COMMENT_START = ";";
+	private static final String CUE = "> ";
+	private static final String NOCHECKSUM = "NOCHECKSUM ";
+	private static final String BADCHECKSUM = "BADCHECKSUM ";
+	private static final String BADLINENUM = "BADLINENUM ";
+	private static final String NEWLINE = "\n";
+	private static final String COMMENT_START = ";";
 
 	
 	private String[] portsDetected;
@@ -44,14 +44,14 @@ implements SerialPortEventListener, ActionListener {
 	private Preferences prefs;
 	
 	// menus & GUIs
-	JTextArea log = new JTextArea();
-	JScrollPane logPane;
+	private JTextArea log = new JTextArea();
+	private JScrollPane logPane;
     private JMenuItem [] buttonPorts;
     private JMenuItem [] buttonBauds;
     
     // communications
-    String inputBuffer;
-    ArrayList<String> commandQueue = new ArrayList<String>();
+	private String inputBuffer;
+	private ArrayList<String> commandQueue = new ArrayList<String>();
 
     // Listeners which should be notified of a change to the percentage.
     private ArrayList<SerialConnectionReadyListener> listeners = new ArrayList<SerialConnectionReadyListener>();

--- a/java/src/com/marginallyclever/gcodesender/StatusBar.java
+++ b/java/src/com/marginallyclever/gcodesender/StatusBar.java
@@ -5,7 +5,7 @@ import java.awt.Dimension;
 import javax.swing.JLabel;
 
 public class StatusBar extends JLabel {
-	static final long serialVersionUID=1;
+	private static final long serialVersionUID=1;
 
     /** Creates a new instance of StatusBar */
     public StatusBar() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat