### PR TITLE
Multiple quality improvements - squid:S1943, findbugs:DM_STRING_CTOR

### DIFF
--- a/java/src/com/marginallyclever/gcodesender/GcodeSender.java
+++ b/java/src/com/marginallyclever/gcodesender/GcodeSender.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Scanner;
@@ -297,7 +298,7 @@ implements ActionListener, KeyListener, SerialConnectionReadyListener
 			HttpURLConnection conn = (HttpURLConnection) github.openConnection();
 			conn.setInstanceFollowRedirects(false);  //you still need to handle redirect manully.
 			HttpURLConnection.setFollowRedirects(false);
-			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
 
 			String inputLine;
 			if ((inputLine = in.readLine()) != null) {
@@ -452,7 +453,7 @@ implements ActionListener, KeyListener, SerialConnectionReadyListener
 		closeFile();
 
 	    try {
-	    	Scanner scanner = new Scanner(new FileInputStream(filename));
+			Scanner scanner = new Scanner(new FileInputStream(filename), "UTF-8");
 	    	linesTotal=0;
 	    	gcode = new ArrayList<String>();
 		    try {
@@ -501,7 +502,7 @@ implements ActionListener, KeyListener, SerialConnectionReadyListener
 
 		// update prefs
 		for(i=0;i<cnt;++i) {
-			if( recentFiles[i]==null ) recentFiles[i] = new String("");
+			if( recentFiles[i]==null ) recentFiles[i] = "";
 			if( !recentFiles[i].isEmpty() ) {
 				prefs.put(RECENT_FILES+i, recentFiles[i]);
 			}

--- a/java/src/com/marginallyclever/gcodesender/Generators/HilbertCurveGenerator.java
+++ b/java/src/com/marginallyclever/gcodesender/Generators/HilbertCurveGenerator.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.Box;
 import javax.swing.JButton;
@@ -96,9 +97,9 @@ public class HilbertCurveGenerator implements GcodeGenerator {
 			String outputFile = System.getProperty("user.dir") + "/" + "TEMP.NGC";
 			System.out.println("output file = "+outputFile);
 			OutputStream output = new FileOutputStream(outputFile);
-			output.write(new String("G28\n").getBytes());
-			output.write(new String(G90_NL).getBytes());
-			output.write(new String("G54 X-30 Z-"+ toolOffsetZ +"\n").getBytes());
+			output.write("G28\n".getBytes(StandardCharsets.UTF_8));
+			output.write(G90_NL.getBytes(StandardCharsets.UTF_8));
+			output.write(("G54 X-30 Z-"+ toolOffsetZ +"\n").getBytes(StandardCharsets.UTF_8));
 			
 			turtleX =0;
 			turtleY =0;
@@ -107,32 +108,32 @@ public class HilbertCurveGenerator implements GcodeGenerator {
 			turtleStep = (float)((xmax-xmin) / (Math.pow(2, order)));
 
 			// Draw bounding box
-			output.write(new String(G90_NL).getBytes());
-			output.write(new String("G0 Z"+ zUp +"\n").getBytes());
-			output.write(new String("G0 X"+xmax+" Y"+ymax+"\n").getBytes());
-			output.write(new String("G0 Z"+ zDown +"\n").getBytes());
-			output.write(new String("G0 X"+xmax+" Y"+ymin+"\n").getBytes());
-			output.write(new String("G0 X"+xmin+" Y"+ymin+"\n").getBytes());
-			output.write(new String("G0 X"+xmin+" Y"+ymax+"\n").getBytes());
-			output.write(new String("G0 X"+xmax+" Y"+ymax+"\n").getBytes());
-			output.write(new String("G0 Z"+ zUp +"\n").getBytes());
+			output.write(G90_NL.getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 Z"+ zUp +"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 X"+xmax+" Y"+ymax+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 Z"+ zDown +"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 X"+xmax+" Y"+ymin+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 X"+xmin+" Y"+ymin+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 X"+xmin+" Y"+ymax+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 X"+xmax+" Y"+ymax+"\n").getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 Z"+ zUp +"\n").getBytes(StandardCharsets.UTF_8));
 
 			// move to starting position
-			output.write(new String("G91\n").getBytes());
-			output.write(new String("G0 X"+(-turtleStep /2)+" Y"+(-turtleStep /2)+"\n").getBytes());
+			output.write("G91\n".getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 X"+(-turtleStep /2)+" Y"+(-turtleStep /2)+"\n").getBytes(StandardCharsets.UTF_8));
 						
 			// do the curve
-			output.write(new String(G90_NL).getBytes());
-			output.write(new String("G0 Z"+ zDown +"\n").getBytes());
+			output.write(G90_NL.getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 Z"+ zDown +"\n").getBytes(StandardCharsets.UTF_8));
 			
-			output.write(new String("G91\n").getBytes());
+			output.write("G91\n".getBytes(StandardCharsets.UTF_8));
 			hilbert(output,order);
 			
-			output.write(new String(G90_NL).getBytes());
-			output.write(new String("G0 Z"+ zUp +"\n").getBytes());
+			output.write(G90_NL.getBytes(StandardCharsets.UTF_8));
+			output.write(("G0 Z"+ zUp +"\n").getBytes(StandardCharsets.UTF_8));
 
 			// finish up
-			output.write(new String("G28\n").getBytes());
+			output.write("G28\n".getBytes(StandardCharsets.UTF_8));
 			
         	output.flush();
 	        output.close();
@@ -190,6 +191,6 @@ public class HilbertCurveGenerator implements GcodeGenerator {
 
     
     public void turtle_goForward(OutputStream output) throws IOException {
-    	output.write(new String("G0 X"+(turtleDx * turtleStep)+" Y"+(turtleDy * turtleStep)+"\n").getBytes());
+		output.write(("G0 X"+(turtleDx * turtleStep)+" Y"+(turtleDy * turtleStep)+"\n").getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/java/src/com/marginallyclever/gcodesender/SerialConnection.java
+++ b/java/src/com/marginallyclever/gcodesender/SerialConnection.java
@@ -7,6 +7,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.prefs.Preferences;
 
@@ -103,7 +104,7 @@ implements SerialPortEventListener, ActionListener {
             	int len = events.getEventValue();
 				byte [] buffer = serialPort.readBytes(len);
 				if( len>0 ) {
-					rawInput = new String(buffer,0,len);
+					rawInput = new String(buffer,0,len, StandardCharsets.UTF_8);
 					inputBuffer+=rawInput;
 					// each line ends with a \n.
 					for( x=inputBuffer.indexOf("\n"); x!=-1; x=inputBuffer.indexOf("\n") ) {
@@ -229,7 +230,7 @@ implements SerialPortEventListener, ActionListener {
 			command=commandQueue.remove(0);
 			if(!command.endsWith("\n")) command+="\n";
 			
-			serialPort.writeBytes(command.getBytes());
+			serialPort.writeBytes(command.getBytes(StandardCharsets.UTF_8));
 			waitingForCue=true;
 		}
 		catch(IndexOutOfBoundsException e1) {}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1943 - Classes and methods that rely on the default system encoding should not be used
findbugs:DM_STRING_CTOR - Performance - Method invokes inefficient new String(String) constructor

You can find more information about the issues here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943
https://dev.eclipse.org/sonar/coding_rules#q=findbugs:DM_STRING_CTOR

Please let me know if you have any questions.

M-Ezzat
